### PR TITLE
Add country code to hotspot config

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -51,7 +51,8 @@ Returns a dictionary describing current box configuration.
               "dhcp_range": "10.0.0.100-255",
               "hotspot": {
                 "ssid": "foo",
-                "password": "bar"
+                "password": "bar",
+                "country_code": "RO"
               },
               "eth": false
             },
@@ -91,7 +92,8 @@ Returns a dictionary describing current box configuration.
               "dhcp_range": "192.168.0.60-99",
               "hotspot": {
                 "ssid": "starbucks",
-                "password": "mcdonalds"
+                "password": "mcdonalds",
+                "country_code": "US"
               },
               "eth": true
             },
@@ -124,7 +126,8 @@ Returns a dictionary describing current box configuration.
               "dhcp_range": "192.168.0.60-99",
               "hotspot": {
                 "ssid": "ACME CONSULTING",
-                "password": "bugs bunny 123"
+                "password": "bugs bunny 123",
+                "country_code": "DE"
               },
               "eth": false
             },
@@ -159,7 +162,8 @@ Updates the configuration of a running Liquid Node.
               "dhcp_range": "10.0.0.100-255",
               "hotspot": {
                 "ssid": "foo",
-                "password": "bar"
+                "password": "bar",
+                "country_code": "RO"
               },
               "eth": false
             },


### PR DESCRIPTION
Even if we don't use the country code initially, it should be user-configurable, so let's add it to the API.

By the way, I can't edit the file in apiary, it's tied to @gabriel-v's account.
